### PR TITLE
Fix support for node v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "codecov": "^3.0.0",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-import": "^2.10.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-standard": "^3.0.1",
@@ -84,10 +84,8 @@
     "postcss-parser-tests": "^6.2.1",
     "postcss-safe-parser": "^3.0.1",
     "postcss-sass": "^0.3.0",
-    "postcss-scss": "^1.0.4",
+    "postcss-scss": "^1.0.5",
     "strip-bom": "^3.0.0",
-    "stylefmt": "^6.0.0",
-    "stylelint": "^9.1.3",
     "sugarss": "^1.0.1"
   }
 }

--- a/test/html.js
+++ b/test/html.js
@@ -2,8 +2,6 @@
 
 const expect = require("chai").expect;
 const autoprefixer = require("autoprefixer");
-const stylelint = require("stylelint");
-const stylefmt = require("stylefmt");
 const postcss = require("postcss");
 const syntax = require("../");
 
@@ -54,44 +52,6 @@ describe("html tests", () => {
 			].join("\n"));
 		});
 	});
-	it("stylelint", () => {
-		return postcss([
-			stylelint({
-				config: {
-					rules: {
-						indentation: 2,
-						"font-family-no-duplicate-names": true,
-					},
-				},
-			}),
-		]).process([
-			"<html>",
-			"<head>",
-			"<style>",
-			"a {",
-			"\tdisplay: flex;",
-			"}",
-			"</style>",
-			"</head>",
-			"<body>",
-			"<div style=\"font-family: serif, serif;\">",
-			"</div>",
-			"</body>",
-			"</html>",
-		].join("\n"), {
-			syntax,
-			from: "stylelint.html",
-		}).then(result => {
-			const errors = result.messages;
-			expect(errors).to.have.lengthOf(2);
-			expect(errors[0].rule).to.equal("indentation");
-			expect(errors[0].line).to.equal(5);
-			expect(errors[0].column).to.equal(2);
-			expect(errors[1].rule).to.equal("font-family-no-duplicate-names");
-			expect(errors[1].line).to.equal(10);
-			expect(errors[1].column).to.equal(33);
-		});
-	});
 
 	it("less", () => {
 		const less = [
@@ -114,7 +74,6 @@ describe("html tests", () => {
 				expect(root.nodes).to.have.lengthOf(2);
 				expect(root.toString()).equal(less);
 			},
-			stylefmt,
 		]).process(less, {
 			syntax: syntax(),
 			from: "less.html",
@@ -173,7 +132,6 @@ describe("html tests", () => {
 				expect(root.nodes).to.have.lengthOf(2);
 				expect(root.toString()).equal(less);
 			},
-			stylefmt,
 		]).process(less, {
 			syntax: syntax(),
 			from: "less.html",

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const expect = require("chai").expect;
-const stylefmt = require("stylefmt");
 const postcss = require("postcss");
 const syntax = require("../");
 
@@ -90,39 +89,6 @@ describe("markdown tests", () => {
 			from: "without_code_blocks.md",
 		}).then(result => {
 			expect(result.content).to.equal("# Hi\n");
-		});
-	});
-
-	it("stylefmt", () => {
-		const source = [
-			"title: Something Special",
-			"```css",
-			"    .foo {",
-			"    color: pink;",
-			"    }",
-			"      .bar {}",
-			"```",
-			"And the end.",
-		].join("\n");
-		const code = [
-			"title: Something Special",
-			"```css",
-			".foo {",
-			"\tcolor: pink;",
-			"}",
-			"",
-			".bar {",
-			"}",
-			"```",
-			"And the end.",
-		].join("\n");
-		return postcss([
-			stylefmt,
-		]).process(source, {
-			syntax,
-			from: "stylefmt.md",
-		}).then(result => {
-			expect(result.content).to.equal(code);
 		});
 	});
 });


### PR DESCRIPTION
Remove `stylelint` from testcase for compatible with node v4